### PR TITLE
All ambiguous date entries assume a future date

### DIFF
--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -102,16 +102,16 @@ function getUserChildLabels(label) {
 function parseDate(str) {  
  // return Date.parse(str);
    if(dateConversionRequired(str)){
-       return convertToUserDate(Date.create(str));
+       return convertToUserDate(Date.future(str));
    }
   
-  return Date.create(str);
+  return Date.future(str);
 }
 
 function parseDateFormat(str) { 
    
  // var date = Date.parse(str);
-  var date = Date.create(str);
+  var date = Date.future(str);
   if (date.isValid() && date.isFuture()) {
     if(dateConversionRequired(str)){
        return convertToUserDate(date).full();


### PR DESCRIPTION
Since it doesn't make sense to assume a past date/time to send an email message, all ambiguous entries such as "7am" (when it is currently "9am") will assume "7am tomorrow".

Solves https://github.com/webdigi/GmailScheduler/issues/7 and possibly the confusion behind https://github.com/webdigi/GmailScheduler/issues/3