### PR TITLE
This resolves the timezone issue

### DIFF
--- a/src/Utils.gs
+++ b/src/Utils.gs
@@ -113,10 +113,7 @@ function parseDateFormat(str) {
  // var date = Date.parse(str);
   var date = Date.future(str);
   if (date.isValid() && date.isFuture()) {
-    if(dateConversionRequired(str)){
-       return convertToUserDate(date).full();
-    }
-    return date.full();
+    return convertToUserDate(date).full();
   }
 
   return null;


### PR DESCRIPTION
This resolves the timezone issue (issue https://github.com/webdigi/GmailScheduler/issues/3) where some date/time entries miscalculated whether it was today or tomorrow.

The issue is that SugarJS doesn't take into account the timezone. This pull request forces the use of Google's `Utilities.formatDate()`, which takes into account the timezone. Previously, when when a date wasn't "converted", it simply used the SugarJS method to create the date (which didn't take into account the timezone). But with this change, the selected timezone will always be taken into account.